### PR TITLE
add NewWindow action

### DIFF
--- a/cool-retro-term.desktop
+++ b/cool-retro-term.desktop
@@ -9,3 +9,9 @@ StartupNotify=true
 Terminal=false
 Type=Application
 Keywords=shell;prompt;command;commandline;
+Actions=NewWindow;
+
+[Desktop Action NewWindow]
+Name=New Window
+Icon=cool-retro-term
+Exec=cool-retro-term


### PR DESCRIPTION
I interpreted issue #247 as a way to open multiple windows, not tabs.  This change doesn't address the requested hotkey, but does at least make it possible to open a new CRT window via the launcher, as with pantheon-terminal.